### PR TITLE
Update colophon.xhtml

### DIFF
--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -24,7 +24,7 @@
 			<a href="https://standardebooks.org/ebooks/ernest-hemingway/short-fiction#page-scans">various sources</a>.</p>
 			<p>The cover page is adapted from<br/>
 			<i epub:type="se:name.visual-art.painting">Bullfight in a Divided Ring</i>,<br/>
-			by<br/>
+			completed in 1867 by<br/>
 			<a href="https://en.wikipedia.org/wiki/Francisco_Goya">Francisco Goya</a>.<br/>
 			The cover and title pages feature the<br/>
 			<b epub:type="se:name.visual-art.typeface">League Spartan</b> and <b epub:type="se:name.visual-art.typeface">Sorts Mill Goudy</b><br/>


### PR DESCRIPTION
Added the year of completion for the cover artwork. 

- Source: https://standardebooks.org/artworks/francisco-de-goya-y-lucientes/bullfight-in-a-divided-ring

Note:
Francisco Goya died in 1828. So, the 1867 date seems wrong. But that's the date I found on the website (Standard Ebooks). On Google Arts and Culture, the date is 1800/1829. I'll leave it up to you to choose whichever of the two seems best.

Google Arts and Culture link: https://artsandculture.google.com/asset/bullfight-in-a-divided-ring-goya-francisco-de-goya-y-lucientes/kAFXj5ds2VU6zw